### PR TITLE
deps:升级相关依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,25 +24,14 @@
 
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-core</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.12</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.15</version>
+      <version>1.2.12</version>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>
@@ -52,12 +41,12 @@
     <dependency>
       <groupId>com.tencentcloudapi.cls</groupId>
       <artifactId>tencentcloud-cls-sdk-java</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.14</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.13.1</version>
+      <version>2.13.5</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
tencentcloud-cls-sdk-java升级到1.0.14
ch.qos.logback升级到1.2.12
jackson升级到2.13.5
移除无用的org.slf4j、junit